### PR TITLE
HOS-39 git-crypt install should take 1 second

### DIFF
--- a/git-crypt-unlock/action.yaml
+++ b/git-crypt-unlock/action.yaml
@@ -15,12 +15,6 @@ runs:
     using: 'composite'
     steps:
         -   name: Install packages
-            shell: bash
-            run: |
-                sudo apt update
-                sudo apt install -y git-crypt
-
-        -   name: Install packages
             uses: awalsh128/cache-apt-pkgs-action@latest
             with:
                 packages: git-crypt

--- a/git-crypt-unlock/action.yaml
+++ b/git-crypt-unlock/action.yaml
@@ -20,6 +20,12 @@ runs:
                 sudo apt update
                 sudo apt install -y git-crypt
 
+        -   name: Install packages
+            uses: awalsh128/cache-apt-pkgs-action@latest
+            with:
+                packages: git-crypt
+                version: 1.0
+
         -   name: Decrypt with git-crypt
             shell: bash
             run: |


### PR DESCRIPTION
instead of 30 seconds.